### PR TITLE
pytestがフリーズせずタイムアウトするようにpytest.iniを追加

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = -q -vv -ra --maxfail=1 --timeout=5
+addopts = -vv -ra --maxfail=1 --timeout=5
 timeout_method = thread

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q -vv -ra --maxfail=1 --timeout=5
+timeout_method = thread

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ httpx==0.28.1
 pydantic==2.11.9
 email-validator==2.3.0
 pydantic_settings==2.11.0
+pytest-timeout==2.3.1

--- a/tests/test_customers_concurrency.py
+++ b/tests/test_customers_concurrency.py
@@ -2,11 +2,12 @@ from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 
 
-def _post(client, i):
-    return client.post("/customers", json={"name": f"U{i}", "email": f"u{i}@ex.com"})
-
-
 def test_many_parallel_posts(client):
+    def _post(client, i):
+        return client.post(
+            "/customers", json={"name": f"U{i}", "email": f"u{i}@ex.com"}
+        )
+
     with ThreadPoolExecutor(max_workers=16) as ex:
         results = list(ex.map(_post, repeat(client), range(200)))
     assert all(r.status_code == 200 for r in results)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- テスト
  - グローバルなテストタイムアウトと早期打ち切りを導入し、信頼性とフィードバック速度を向上。
  - 出力を詳細表示し失敗理由の可視性を改善。
  - 併行実行テストのヘルパーをテスト内へ移動し、可読性とスコープの明確化を実施（動作は不変）。

- 雑務
  - テストタイムアウト機能を有効にする依存を追加。
  - テスト実行の既定オプションを設定し、安定した実行環境を整備。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->