### PR TITLE
商品登録エンドポイント POST /productsを実装。

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
 
-from .schemas import CustomerCreate, CustomerWithId
+from .schemas import CustomerCreate, CustomerWithId, ProductCreate, ProductWithId
 from .services import create_customer
+from .services_products import create_product
 
 app = FastAPI()
 
@@ -14,3 +15,8 @@ async def health_check() -> dict[str, bool]:
 @app.post("/customers", response_model=CustomerWithId)
 async def post_customer(body: CustomerCreate) -> CustomerWithId:
     return create_customer(body.name, body.email)
+
+
+@app.post("/products", response_model=ProductWithId)
+async def post_product(body: ProductCreate) -> ProductWithId:
+    return create_product(body.name, body.unit_price)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -38,3 +38,28 @@ class CustomerCreate(BaseModel):
         return validate_name_trim_and_noempty(v)
 
     model_config = ConfigDict(alias_generator=to_camel)
+
+
+class ProductCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    unit_price: int = Field(..., ge=1, le=1_000_000)
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def name_trim_and_noempty(cls, v: str) -> str:
+        return validate_name_trim_and_noempty(v)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class ProductWithId(BaseModel):
+    prod_id: str
+    name: str
+    unit_price: int
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def trim_name(cls, v: str) -> str:
+        return validate_name_trim_and_noempty(v)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/app/services_products.py
+++ b/app/services_products.py
@@ -1,0 +1,36 @@
+import threading
+import uuid
+from typing import Dict
+
+from .core.errors import Conflict
+from .schemas import ProductWithId
+
+# In-memory storage
+_lock_p = threading.RLock()
+_products_by_id: Dict[str, ProductWithId] = {}
+_prodid_by_name: Dict[str, str] = {}
+
+
+def new_prod_id() -> str:
+    with _lock_p:
+        max_attempts = 100
+        for _ in range(max_attempts):
+            prod_id = f"P_{uuid.uuid4().hex[:8]}"
+            if prod_id not in _products_by_id:
+                return prod_id
+        raise RuntimeError(
+            "Failed to generate unique customer ID after maximum attempts"
+        )
+
+
+def create_product(name: str, unit_price) -> ProductWithId:
+    with _lock_p:
+        name_lower = name.strip().lower()
+        if name_lower in _prodid_by_name:
+            raise Conflict("NAME_DUP", "name already exists")
+        prod_id = new_prod_id()
+        product = ProductWithId(prod_id=prod_id, name=name, unit_price=unit_price)
+
+        _products_by_id[prod_id] = product
+        _prodid_by_name[name_lower] = prod_id
+        return product

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,20 @@ def client():
 def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""
     from app.services import _custid_by_email, _customers_by_id, _lock
+    from app.services_products import _lock_p, _prodid_by_name, _products_by_id
 
     with _lock:
         _customers_by_id.clear()
         _custid_by_email.clear()
+    with _lock_p:
+        _products_by_id.clear()
+        _prodid_by_name.clear()
     try:
         yield
     finally:
         with _lock:
             _customers_by_id.clear()
             _custid_by_email.clear()
+        with _lock_p:
+            _products_by_id.clear()
+            _prodid_by_name.clear()

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tests.helpers import post_json
+
+
+@pytest.mark.parametrize("name", [" ", "A" * 101])
+def test_create_product_name_boundary(client, name):
+    response = post_json(client, "/products", {"name": name, "unitPrice": 10000})
+    # TODO: 統一エラーフォーマット実装後は400のみを期待
+    assert response.status_code in (400, 422)
+
+
+def test_create_product_ok(client):
+    response = post_json(client, "/products", {"name": "Pen", "unitPrice": 100})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["prodId"].startswith("P_")
+    assert body["name"] == "Pen"
+    assert body["unitPrice"] == 100
+
+
+def test_create_product_duplicate_name_case_insensitive(client):
+    first_response = post_json(
+        client, "/products", {"name": "Notebook", "unitPrice": 500}
+    )
+    assert first_response.status_code == 200
+    second_response = post_json(
+        client, "/products", {"name": "Notebook", "unitPrice": 800}
+    )
+    assert second_response.status_code == 409
+    assert second_response.json()["detail"]["code"] == "NAME_DUP"


### PR DESCRIPTION
## 目的（ユーザストーリー 1行）
- 例）ユーザとして、重複メールをエラーにしたい。なぜなら…
## 変更内容（縦切りの範囲）
- Controller / Service / Storage（Repository）/ DTO / テスト
- I/F変更: なし（※原則なし）
## 設計ポイント
- 例外とHTTPマッピング（400/404/409）
## テスト
- 正常: 1
- 異常: 2
- カバレッジ: 100%
## 影響範囲
- 特になし
## 動作確認
- `pytest -q`- curl
## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新