### PR TITLE
エラー422を400にそろえるためのグローバル例外ハンドラを追加

### DIFF
--- a/app/core/exception_handlers.py
+++ b/app/core/exception_handlers.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -14,7 +16,7 @@ def include_handlers(app: FastAPI):
             content={
                 "code": "VALIDATION_ERROR",
                 "message": "Invalid request",
-                "details": str(exc),
+                "details": json.loads(json.dumps(exc.errors(), default=str)),
             },
         )
 
@@ -27,6 +29,6 @@ def include_handlers(app: FastAPI):
             content={
                 "code": "VALIDATION_ERROR",
                 "message": "Invalid data",
-                "details": str(exc),
+                "details": json.loads(json.dumps(exc.errors(), default=str)),
             },
         )

--- a/app/core/exception_handlers.py
+++ b/app/core/exception_handlers.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+
+def include_handlers(app: FastAPI):
+    @app.exception_handler(RequestValidationError)
+    async def handle_request_validation_error(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "VALIDATION_ERROR",
+                "message": "Invalid request",
+                "details": str(exc),
+            },
+        )
+
+    @app.exception_handler(ValidationError)
+    async def handle_pydantic_validation_error(
+        request: Request, exc: ValidationError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "VALIDATION_ERROR",
+                "message": "Invalid data",
+                "details": str(exc),
+            },
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI, Response, status
 
+from .core.exception_handlers import include_handlers
 from .schemas import CustomerCreate, CustomerWithId, ProductCreate, ProductWithId
 from .services import create_customer
 from .services_products import create_product
 
 app = FastAPI()
+include_handlers(app)
 
 
 @app.get("/health")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -37,7 +37,7 @@ class CustomerCreate(BaseModel):
     def name_trim_and_noempty(cls, v: str) -> str:
         return validate_name_trim_and_noempty(v)
 
-    model_config = ConfigDict(alias_generator=to_camel)
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
 
 class ProductCreate(BaseModel):

--- a/tests/test_customers_api.py
+++ b/tests/test_customers_api.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from tests.helpers import post_json
@@ -6,8 +8,7 @@ from tests.helpers import post_json
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_customer_name_boundary(client, name):
     response = post_json(client, "/customers", {"name": name, "email": "b@example.com"})
-    # TODO: 統一エラーフォーマット実装後は400のみを期待
-    assert response.status_code in (400, 422)
+    assert response.status_code == 400
 
 
 def test_create_customer_ok(client):
@@ -16,7 +17,7 @@ def test_create_customer_ok(client):
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["custId"].startswith("C_")
+    assert re.fullmatch(r"C_[0-9a-f]{8}", body["custId"])
     assert body["name"] == "Alice"
     assert body["email"] == "a@example.com"
 
@@ -37,11 +38,11 @@ def test_create_customer_invalid_email(client):
     response = post_json(
         client, "/customers", {"name": "Test", "email": "invalid-email"}
     )
-    assert response.status_code == 422  # Validation error
+    assert response.status_code == 400
 
 
 def test_create_customer_empty_name(client):
     response = post_json(
         client, "/customers", {"name": "", "email": "test@example.com"}
     )
-    assert response.status_code == 422
+    assert response.status_code == 400

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from tests.helpers import post_json
@@ -6,15 +8,13 @@ from tests.helpers import post_json
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_product_name_boundary(client, name):
     response = post_json(client, "/products", {"name": name, "unitPrice": 10000})
-    # TODO: 統一エラーフォーマット実装後は400のみを期待
-    assert response.status_code in (400, 422)
+    assert response.status_code == 400
 
 
 @pytest.mark.parametrize("price", [0, 1_000_001])
 def test_create_product_price_boundary(client, price):
     response = post_json(client, "/products", {"name": "P", "unitPrice": price})
-    # TODO: 統一エラーフォーマット実装後は400のみを期待
-    assert response.status_code in (400, 422)
+    assert response.status_code == 400
 
 
 def test_create_product_ok(client):
@@ -22,8 +22,6 @@ def test_create_product_ok(client):
     assert response.status_code == 201
     assert "Location" in response.headers
     body = response.json()
-    import re
-
     assert re.fullmatch(r"P_[0-9a-f]{8}", body["prodId"])
     assert body["name"] == "Pen"
     assert body["unitPrice"] == 100

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,30 @@
+import re
+
+from tests.helpers import post_json
+
+
 def test_health_ok(client):
     r = client.get("/health")
     assert r.status_code == 200
     assert r.json() == {"ok": True}
+
+
+def test_create_customer_ok(client):
+    response = post_json(
+        client, "/customers", {"name": "Alice", "email": "a@example.com"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert re.fullmatch(r"C_[0-9a-f]{8}", body["custId"])
+    assert body["name"] == "Alice"
+    assert body["email"] == "a@example.com"
+
+
+def test_create_product_ok(client):
+    response = post_json(client, "/products", {"name": "Pen", "unitPrice": 100})
+    assert response.status_code == 201
+    assert "Location" in response.headers
+    body = response.json()
+    assert re.fullmatch(r"P_[0-9a-f]{8}", body["prodId"])
+    assert body["name"] == "Pen"
+    assert body["unitPrice"] == 100


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バリデーション例外を一元処理し、エラー時に code/message/details を含むJSONで分かりやすく返却。
  * 顧客作成でエイリアス名だけでなくフィールド名でも入力を受け付け可能に。
* **不具合修正**
  * バリデーション失敗時のHTTPステータスを422から400に統一。
  * 生成IDの形式を厳格化し、custId/prodIdのパターン検証を強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->