### PR TITLE
X-API-KEY認証を各エンドポイントに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ ChatGPT により生成された詳細設計シートに基づき、勝手に仕
 
 ```bash
 python -m venv venv
-source venv/bin/activate  # Windowsは venv\Scripts\activate
+# Linux/macOS
+source venv/bin/activate
+export API_KEY=test-secret
+
+# Windows
+venv\Scripts\activate
 set API_KEY=test-secret
 pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ ChatGPT により生成された詳細設計シートに基づき、勝手に仕
 ```bash
 python -m venv venv
 source venv/bin/activate  # Windowsは venv\Scripts\activate
+set API_KEY=test-secret
 pip install -r requirements.txt
 ```
 

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,32 @@
+import os
+
+from fastapi import Header, HTTPException, status
+
+API_KEY_ENV = "API_KEY"
+
+
+def get_expected_api_key() -> str:
+    key = os.getenv(API_KEY_ENV)
+    if not key:
+        raise RuntimeError(f"Environment variable {API_KEY_ENV} is not set")
+    return key
+
+
+async def require_api_key(
+    x_api_key: str | None = Header(default=None, alias="X-API-KEY")
+):
+    """
+    認可用の依存関数
+    - ヘッダ未指定 or 不一致 -> 401
+    """
+    expected = get_expected_api_key()
+    if not x_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="X-API-KEY header required",
+        )
+    if x_api_key != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,15 +1,26 @@
 import os
+import secrets
 
 from fastapi import Header, HTTPException, status
 
 API_KEY_ENV = "API_KEY"
 
+# アプリケーション起動時に一度だけ検証
+_EXPECTED_API_KEY: str | None = None
+
+
+def init_api_key():
+    """起動時に呼び出してAPI_KEYを検証・キャッシュ"""
+    global _EXPECTED_API_KEY
+    _EXPECTED_API_KEY = os.getenv(API_KEY_ENV)
+    if not _EXPECTED_API_KEY:
+        raise RuntimeError(f"Environment variable {API_KEY_ENV} is not set")
+
 
 def get_expected_api_key() -> str:
-    key = os.getenv(API_KEY_ENV)
-    if not key:
+    if _EXPECTED_API_KEY is None:
         raise RuntimeError(f"Environment variable {API_KEY_ENV} is not set")
-    return key
+    return _EXPECTED_API_KEY
 
 
 async def require_api_key(
@@ -25,7 +36,7 @@ async def require_api_key(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="X-API-KEY header required",
         )
-    if x_api_key != expected:
+    if not secrets.compare_digest(x_api_key, expected):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, FastAPI, Response, status
 
-from .core.auth import require_api_key
+from .core.auth import init_api_key, require_api_key
 from .core.exception_handlers import include_handlers
 from .schemas import CustomerCreate, CustomerWithId, ProductCreate, ProductWithId
 from .services import create_customer
@@ -8,6 +8,7 @@ from .services_products import create_product
 
 app = FastAPI()
 include_handlers(app)
+init_api_key()
 
 
 @app.get("/health")

--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,10 @@ async def post_customer(body: CustomerCreate) -> CustomerWithId:
 
 
 @app.post(
-    "/products", response_model=ProductWithId, status_code=status.HTTP_201_CREATED
+    "/products",
+    response_model=ProductWithId,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_api_key)],
 )
 async def post_product(body: ProductCreate, response: Response) -> ProductWithId:
     product = create_product(body.name, body.unit_price)

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, Response, status
+from fastapi import Depends, FastAPI, Response, status
 
+from .core.auth import require_api_key
 from .core.exception_handlers import include_handlers
 from .schemas import CustomerCreate, CustomerWithId, ProductCreate, ProductWithId
 from .services import create_customer
@@ -14,7 +15,9 @@ async def health_check() -> dict[str, bool]:
     return {"ok": True}
 
 
-@app.post("/customers", response_model=CustomerWithId)
+@app.post(
+    "/customers", response_model=CustomerWithId, dependencies=[Depends(require_api_key)]
+)
 async def post_customer(body: CustomerCreate) -> CustomerWithId:
     return create_customer(body.name, body.email)
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,10 +16,15 @@ async def health_check() -> dict[str, bool]:
 
 
 @app.post(
-    "/customers", response_model=CustomerWithId, dependencies=[Depends(require_api_key)]
+    "/customers",
+    response_model=CustomerWithId,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_api_key)],
 )
-async def post_customer(body: CustomerCreate) -> CustomerWithId:
-    return create_customer(body.name, body.email)
+async def post_customer(body: CustomerCreate, response: Response) -> CustomerWithId:
+    customer = create_customer(body.name, body.email)
+    response.headers["Location"] = f"/customers/{customer.cust_id}"
+    return customer
 
 
 @app.post(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 
+@pytest.fixture(autouse=True)
+def set_api_key_env(monkeypatch):
+    # テスト専用固定キー
+    monkeypatch.setenv("API_KEY", "test-secret")
+    yield
+
+
 @pytest.fixture
 def client():
     from app.main import app  # ← ここでだけ import

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,8 +2,13 @@ from httpx import Response
 from starlette.testclient import TestClient
 
 
-def post_json(client: TestClient, path: str, payload: dict) -> Response:
-    response = client.post(path, json=payload)
+def post_json(
+    client: TestClient, path: str, payload: dict, *, api_key: str | None = None
+) -> Response:
+    headers = {}
+    if api_key is not None:
+        headers["X-API-KEY"] = api_key
+    response = client.post(path, json=payload, headers=headers or None)
     assert (
         response.status_code < 500
     ), f"5xx from {path}: {response.status_code}, {response.text}"

--- a/tests/test_auth_customers.py
+++ b/tests/test_auth_customers.py
@@ -22,6 +22,6 @@ def test_customers_accepts_valid_api_key(client):
         {"name": "A", "email": "a@example.com"},
         api_key="test-secret",
     )
-    assert r.status_code == 200
+    assert r.status_code == 201
     body = r.json()
     assert body["name"] == "A"

--- a/tests/test_auth_customers.py
+++ b/tests/test_auth_customers.py
@@ -1,0 +1,27 @@
+from tests.helpers import post_json
+
+
+def test_customers_requires_api_key(client):
+    r = client.post("/customers", json={"name": "A", "email": "a@example.com"})
+    assert r.status_code == 401
+    assert "X-API-KEY" in r.text
+
+
+def test_customers_rejects_invalid_api_key(client):
+    r = post_json(
+        client, "/customers", {"name": "A", "email": "a@example.com"}, api_key="wrong"
+    )
+    assert r.status_code == 401
+    assert "Invalid API key" in r.text
+
+
+def test_customers_accepts_valid_api_key(client):
+    r = post_json(
+        client,
+        "/customers",
+        {"name": "A", "email": "a@example.com"},
+        api_key="test-secret",
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["name"] == "A"

--- a/tests/test_auth_products.py
+++ b/tests/test_auth_products.py
@@ -1,0 +1,25 @@
+from tests.helpers import post_json
+
+
+def test_products_requires_api_key(client):
+    r = client.post("/products", json={"name": "A", "unitPrice": 1})
+    assert r.status_code == 401
+    assert "X-API-KEY" in r.text
+
+
+def test_products_rejects_invalid_api_key(client):
+    r = post_json(client, "/products", {"name": "A", "unitPrice": 1}, api_key="wrong")
+    assert r.status_code == 401
+    assert "Invalid API key" in r.text
+
+
+def test_products_accepts_valid_api_key(client):
+    r = post_json(
+        client,
+        "/products",
+        {"name": "A", "unitPrice": 1},
+        api_key="test-secret",
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["name"] == "A"

--- a/tests/test_customers_api.py
+++ b/tests/test_customers_api.py
@@ -23,7 +23,8 @@ def test_create_customer_ok(client):
         {"name": "Alice", "email": "a@example.com"},
         api_key="test-secret",
     )
-    assert response.status_code == 200
+    assert response.status_code == 201
+    assert "Location" in response.headers
     body = response.json()
     assert re.fullmatch(r"C_[0-9a-f]{8}", body["custId"])
     assert body["name"] == "Alice"
@@ -37,7 +38,8 @@ def test_create_customer_duplicate_email(client):
         {"name": "Bob", "email": "duplicate@example.com"},
         api_key="test-secret",
     )
-    assert first_response.status_code == 200
+    assert first_response.status_code == 201
+    assert "Location" in first_response.headers
     second_response = post_json(
         client,
         "/customers",

--- a/tests/test_customers_api.py
+++ b/tests/test_customers_api.py
@@ -7,13 +7,21 @@ from tests.helpers import post_json
 
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_customer_name_boundary(client, name):
-    response = post_json(client, "/customers", {"name": name, "email": "b@example.com"})
+    response = post_json(
+        client,
+        "/customers",
+        {"name": name, "email": "b@example.com"},
+        api_key="test-secret",
+    )
     assert response.status_code == 400
 
 
 def test_create_customer_ok(client):
     response = post_json(
-        client, "/customers", {"name": "Alice", "email": "a@example.com"}
+        client,
+        "/customers",
+        {"name": "Alice", "email": "a@example.com"},
+        api_key="test-secret",
     )
     assert response.status_code == 200
     body = response.json()
@@ -24,11 +32,17 @@ def test_create_customer_ok(client):
 
 def test_create_customer_duplicate_email(client):
     first_response = post_json(
-        client, "/customers", {"name": "Bob", "email": "duplicate@example.com"}
+        client,
+        "/customers",
+        {"name": "Bob", "email": "duplicate@example.com"},
+        api_key="test-secret",
     )
     assert first_response.status_code == 200
     second_response = post_json(
-        client, "/customers", {"name": "Charlie", "email": "duplicate@example.com"}
+        client,
+        "/customers",
+        {"name": "Charlie", "email": "duplicate@example.com"},
+        api_key="test-secret",
     )
     assert second_response.status_code == 409
     assert second_response.json()["detail"]["code"] == "EMAIL_DUP"
@@ -36,13 +50,19 @@ def test_create_customer_duplicate_email(client):
 
 def test_create_customer_invalid_email(client):
     response = post_json(
-        client, "/customers", {"name": "Test", "email": "invalid-email"}
+        client,
+        "/customers",
+        {"name": "Test", "email": "invalid-email"},
+        api_key="test-secret",
     )
     assert response.status_code == 400
 
 
 def test_create_customer_empty_name(client):
     response = post_json(
-        client, "/customers", {"name": "", "email": "test@example.com"}
+        client,
+        "/customers",
+        {"name": "", "email": "test@example.com"},
+        api_key="test-secret",
     )
     assert response.status_code == 400

--- a/tests/test_customers_api.py
+++ b/tests/test_customers_api.py
@@ -4,6 +4,8 @@ import pytest
 
 from tests.helpers import post_json
 
+TEST_API_KEY = "test-secret"
+
 
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_customer_name_boundary(client, name):
@@ -11,7 +13,7 @@ def test_create_customer_name_boundary(client, name):
         client,
         "/customers",
         {"name": name, "email": "b@example.com"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert response.status_code == 400
 
@@ -21,7 +23,7 @@ def test_create_customer_ok(client):
         client,
         "/customers",
         {"name": "Alice", "email": "a@example.com"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert response.status_code == 201
     assert "Location" in response.headers
@@ -36,7 +38,7 @@ def test_create_customer_duplicate_email(client):
         client,
         "/customers",
         {"name": "Bob", "email": "duplicate@example.com"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert first_response.status_code == 201
     assert "Location" in first_response.headers
@@ -44,7 +46,7 @@ def test_create_customer_duplicate_email(client):
         client,
         "/customers",
         {"name": "Charlie", "email": "duplicate@example.com"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert second_response.status_code == 409
     assert second_response.json()["detail"]["code"] == "EMAIL_DUP"
@@ -55,7 +57,7 @@ def test_create_customer_invalid_email(client):
         client,
         "/customers",
         {"name": "Test", "email": "invalid-email"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert response.status_code == 400
 
@@ -65,6 +67,6 @@ def test_create_customer_empty_name(client):
         client,
         "/customers",
         {"name": "", "email": "test@example.com"},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert response.status_code == 400

--- a/tests/test_customers_concurrency.py
+++ b/tests/test_customers_concurrency.py
@@ -1,13 +1,16 @@
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 
+from tests.helpers import post_json
+
 
 def test_many_parallel_posts(client):
     def _post(client, i):
-        return client.post(
+        return post_json(
+            client,
             "/customers",
-            json={"name": f"U{i}", "email": f"u{i}@ex.com"},
-            headers={"X-API-KEY": "test-secret"},
+            {"name": f"U{i}", "email": f"u{i}@ex.com"},
+            api_key="test-secret",
         )
 
     with ThreadPoolExecutor(max_workers=16) as ex:

--- a/tests/test_customers_concurrency.py
+++ b/tests/test_customers_concurrency.py
@@ -5,7 +5,9 @@ from itertools import repeat
 def test_many_parallel_posts(client):
     def _post(client, i):
         return client.post(
-            "/customers", json={"name": f"U{i}", "email": f"u{i}@ex.com"}
+            "/customers",
+            json={"name": f"U{i}", "email": f"u{i}@ex.com"},
+            headers={"X-API-KEY": "test-secret"},
         )
 
     with ThreadPoolExecutor(max_workers=16) as ex:

--- a/tests/test_customers_concurrency.py
+++ b/tests/test_customers_concurrency.py
@@ -12,7 +12,7 @@ def test_many_parallel_posts(client):
 
     with ThreadPoolExecutor(max_workers=16) as ex:
         results = list(ex.map(_post, repeat(client), range(200)))
-    assert all(r.status_code == 200 for r in results)
+    assert all(r.status_code == 201 for r in results)
 
     # 全てのレスポンスに有効なIDが含まれていることを確認
     ids = [r.json()["custId"] for r in results]

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -7,18 +7,24 @@ from tests.helpers import post_json
 
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_product_name_boundary(client, name):
-    response = post_json(client, "/products", {"name": name, "unitPrice": 10000})
+    response = post_json(
+        client, "/products", {"name": name, "unitPrice": 10000}, api_key="test-secret"
+    )
     assert response.status_code == 400
 
 
 @pytest.mark.parametrize("price", [0, 1_000_001])
 def test_create_product_price_boundary(client, price):
-    response = post_json(client, "/products", {"name": "P", "unitPrice": price})
+    response = post_json(
+        client, "/products", {"name": "P", "unitPrice": price}, api_key="test-secret"
+    )
     assert response.status_code == 400
 
 
 def test_create_product_ok(client):
-    response = post_json(client, "/products", {"name": "Pen", "unitPrice": 100})
+    response = post_json(
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key="test-secret"
+    )
     assert response.status_code == 201
     assert "Location" in response.headers
     body = response.json()
@@ -29,11 +35,17 @@ def test_create_product_ok(client):
 
 def test_create_product_duplicate_name_case_insensitive(client):
     first_response = post_json(
-        client, "/products", {"name": "Notebook", "unitPrice": 500}
+        client,
+        "/products",
+        {"name": "Notebook", "unitPrice": 500},
+        api_key="test-secret",
     )
     assert first_response.status_code == 201
     second_response = post_json(
-        client, "/products", {"name": "notebook", "unitPrice": 800}
+        client,
+        "/products",
+        {"name": "notebook", "unitPrice": 800},
+        api_key="test-secret",
     )
     assert second_response.status_code == 409
     assert second_response.json()["detail"]["code"] == "NAME_DUP"

--- a/tests/test_products_api.py
+++ b/tests/test_products_api.py
@@ -4,11 +4,13 @@ import pytest
 
 from tests.helpers import post_json
 
+TEST_API_KEY = "test-secret"
+
 
 @pytest.mark.parametrize("name", [" ", "A" * 101])
 def test_create_product_name_boundary(client, name):
     response = post_json(
-        client, "/products", {"name": name, "unitPrice": 10000}, api_key="test-secret"
+        client, "/products", {"name": name, "unitPrice": 10000}, api_key=TEST_API_KEY
     )
     assert response.status_code == 400
 
@@ -16,14 +18,14 @@ def test_create_product_name_boundary(client, name):
 @pytest.mark.parametrize("price", [0, 1_000_001])
 def test_create_product_price_boundary(client, price):
     response = post_json(
-        client, "/products", {"name": "P", "unitPrice": price}, api_key="test-secret"
+        client, "/products", {"name": "P", "unitPrice": price}, api_key=TEST_API_KEY
     )
     assert response.status_code == 400
 
 
 def test_create_product_ok(client):
     response = post_json(
-        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key="test-secret"
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key=TEST_API_KEY
     )
     assert response.status_code == 201
     assert "Location" in response.headers
@@ -38,14 +40,14 @@ def test_create_product_duplicate_name_case_insensitive(client):
         client,
         "/products",
         {"name": "Notebook", "unitPrice": 500},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert first_response.status_code == 201
     second_response = post_json(
         client,
         "/products",
         {"name": "notebook", "unitPrice": 800},
-        api_key="test-secret",
+        api_key=TEST_API_KEY,
     )
     assert second_response.status_code == 409
     assert second_response.json()["detail"]["code"] == "NAME_DUP"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -24,7 +24,9 @@ def test_create_customer_ok(client):
 
 
 def test_create_product_ok(client):
-    response = post_json(client, "/products", {"name": "Pen", "unitPrice": 100})
+    response = post_json(
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key="test-secret"
+    )
     assert response.status_code == 201
     assert "Location" in response.headers
     body = response.json()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -16,7 +16,8 @@ def test_create_customer_ok(client):
         {"name": "Alice", "email": "a@example.com"},
         api_key="test-secret",
     )
-    assert response.status_code == 200
+    assert response.status_code == 201
+    assert "Location" in response.headers
     body = response.json()
     assert re.fullmatch(r"C_[0-9a-f]{8}", body["custId"])
     assert body["name"] == "Alice"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -11,7 +11,10 @@ def test_health_ok(client):
 
 def test_create_customer_ok(client):
     response = post_json(
-        client, "/customers", {"name": "Alice", "email": "a@example.com"}
+        client,
+        "/customers",
+        {"name": "Alice", "email": "a@example.com"},
+        api_key="test-secret",
     )
     assert response.status_code == 200
     body = response.json()


### PR DESCRIPTION
## 目的（ユーザストーリー 1行）
- X-API-KEY認可を各エンドポイントに追加。
## 変更内容（縦切りの範囲）
- テスト
- I/F変更: なし
## 影響範囲
- 既存機能
## 動作確認
- `pytest`
## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 顧客・商品作成エンドポイントでAPIキー認証を導入（X-API-KEYヘッダーが必須）。作成成功時はHTTP 201 Createdを返し、Locationヘッダーで新規リソースURLを返却。

- ドキュメント
  - セットアップ手順にAPI_KEYをtest-secretに設定する一行を追加。

- テスト
  - 全体のテストをAPIキー対応に更新し、テストヘルパーと自動セットアップでテスト用APIキーを注入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->