### PR TITLE
X-API-KEY認証の監査ログ機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ htmlcov/
 # VSCode / JetBrains
 .vscode/
 .idea/
+
+*.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,15 +29,14 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
 
-  # # （任意）ローカルフック：スモークpytest
-  # # ※ tests/test_smoke.py を後で作ったら有効化
-  # - repo: local
-  #   hooks:
-  #     - id: pytest-smoke
-  #       name: pytest (smoke)
-  #       entry: bash -lc 'pytest -q tests/test_smoke.py'
-  #       language: system
-  #       types: [python]
-  #       pass_filenames: false
-  #       stages: [commit] # コミット時に実行
-  #       # ↑ スモークをまだ書いていない間は、このブロックをコメントアウトでもOK
+  # （任意）ローカルフック：スモークpytest
+  # ※ tests/test_smoke.py を後で作ったら有効化
+  - repo: local
+    hooks:
+      - id: pytest-smoke
+        name: pytest (smoke)
+        entry: bash -lc 'pytest -q tests/test_smoke.py'
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [commit] # コミット時に実行

--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ python -m venv venv
 # Linux/macOS
 source venv/bin/activate
 export API_KEY=test-secret
+export API_KEY_HASH_SECRET=hash-secret
 
 # Windows
 venv\Scripts\activate
 set API_KEY=test-secret
+set API_KEY_HASH_SECRET=hash-secret
+
 pip install -r requirements.txt
 ```
 

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import secrets
+from datetime import datetime
 
-from fastapi import Header, HTTPException, status
+from fastapi import Header, HTTPException, Request, status
 
 API_KEY_ENV = "API_KEY"
+logger = logging.getLogger(__name__)
 
 # アプリケーション起動時に一度だけ検証
 _EXPECTED_API_KEY: str | None = None
@@ -24,20 +27,47 @@ def get_expected_api_key() -> str:
 
 
 async def require_api_key(
-    x_api_key: str | None = Header(default=None, alias="X-API-KEY")
+    x_api_key: str | None = Header(default=None, alias="X-API-KEY"),
+    request: Request = None,
 ):
     """
-    認可用の依存関数
+    認可用の依存関数 + 監査ログ
     - ヘッダ未指定 or 不一致 -> 401
     """
+    client_ip = request.client.host if request and request.client else "unknown"
     expected = get_expected_api_key()
+
     if not x_api_key:
+        logger.warning(
+            "Authentication failed - missing API key",
+            extra={
+                "client_ip": client_ip,
+                "timestamp": datetime.utcnow().isoformat(),
+                "reason": "missing_header",
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="X-API-KEY header required",
         )
+
     if not secrets.compare_digest(x_api_key, expected):
+        logger.warning(
+            "Authentication failed - invalid API key",
+            extra={
+                "client_ip": client_ip,
+                "timestamp": datetime.utcnow().isoformat(),
+                "reason": "invalid_key",
+                "key_prefix": x_api_key[:8] if x_api_key else None,
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid API key",
         )
+
+    # 成功ログ
+    logger.info(
+        "Authentication successful",
+        extra={"client_ip": client_ip, "timestamp": datetime.utcnow().isoformat()},
+    )

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import Header, HTTPException, Request, status
 
@@ -42,7 +42,7 @@ async def require_api_key(
             "Authentication failed - missing API key",
             extra={
                 "client_ip": client_ip,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "reason": "missing_header",
             },
         )
@@ -56,7 +56,7 @@ async def require_api_key(
             "Authentication failed - invalid API key",
             extra={
                 "client_ip": client_ip,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "reason": "invalid_key",
             },
         )
@@ -68,5 +68,8 @@ async def require_api_key(
     # 成功ログ
     logger.info(
         "Authentication successful",
-        extra={"client_ip": client_ip, "timestamp": datetime.utcnow().isoformat()},
+        extra={
+            "client_ip": client_ip,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
     )

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -58,7 +58,6 @@ async def require_api_key(
                 "client_ip": client_ip,
                 "timestamp": datetime.utcnow().isoformat(),
                 "reason": "invalid_key",
-                "key_prefix": x_api_key[:8] if x_api_key else None,
             },
         )
         raise HTTPException(

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -27,8 +27,8 @@ def get_expected_api_key() -> str:
 
 
 async def require_api_key(
+    request: Request,
     x_api_key: str | None = Header(default=None, alias="X-API-KEY"),
-    request: Request = None,
 ):
     """
     認可用の依存関数 + 監査ログ

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ LOGGING_CONFIG = {
     },
     "formatters": {
         "json": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "class": "pythonjsonlogger.json.JsonFormatter",
             "format": "%(asctime)s, %(levelname)s %(message)s %(client_ip)s %(timestamp)s %(reason)s",
         }
     },

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import logging.config
+from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, Response, status
 
@@ -27,16 +28,19 @@ LOGGING_CONFIG = {
     "loggers": {"app.core.auth": {"handlers": ["file"], "level": "INFO"}},
 }
 
-app = FastAPI()
 
-
-@app.on_event("startup")
-def configure_logging():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # スタートアップ処理
     logging.config.dictConfig(LOGGING_CONFIG)
+    init_api_key()
+    yield
+    # シャットダウン処理（必要に応じて追加）
 
+
+app = FastAPI(lifespan=lifespan)
 
 include_handlers(app)
-init_api_key()
 
 
 @app.get("/health")

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ LOGGING_CONFIG = {
     "formatters": {
         "json": {
             "class": "pythonjsonlogger.json.JsonFormatter",
-            "format": "%(asctime)s, %(levelname)s %(message)s %(client_ip)s %(timestamp)s %(reason)s",
+            "format": "%(timestamp)s %(levelname)s %(message)s %(client_ip)s %(reason)s",
         }
     },
     "loggers": {"app.core.auth": {"handlers": ["file"], "level": "INFO"}},

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,7 @@ LOGGING_CONFIG = {
     "formatters": {
         "json": {
             "class": "pythonjsonlogger.json.JsonFormatter",
-            "format": "%(timestamp)s %(levelname)s %(message)s %(client_ip)s %(reason)s",
+            "format": "%(timestamp)s %(levelname)s %(message)s %(client_ip)s %(result)s %(key_hash)s %(reason)s",
         }
     },
     "loggers": {"app.core.auth": {"handlers": ["file"], "level": "INFO"}},

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from .services_products import create_product
 
 LOGGING_CONFIG = {
     "version": 1,
+    "disable_existing_loggers": False,
     "handlers": {
         "file": {
             "class": "logging.FileHandler",
@@ -19,16 +20,21 @@ LOGGING_CONFIG = {
     },
     "formatters": {
         "json": {
-            "class": "logging.Formatter",
-            "format": '{"time": "%(asctime)s", "level": "%(levelname)s", "message": "%(message)s", "extra": %(extra)s}',
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "format": "%(asctime)s, %(levelname)s %(message)s %(client_ip)s %(timestamp)s %(reason)s",
         }
     },
     "loggers": {"app.core.auth": {"handlers": ["file"], "level": "INFO"}},
 }
 
-logging.config.dictConfig(LOGGING_CONFIG)
-
 app = FastAPI()
+
+
+@app.on_event("startup")
+def configure_logging():
+    logging.config.dictConfig(LOGGING_CONFIG)
+
+
 include_handlers(app)
 init_api_key()
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+import logging.config
+
 from fastapi import Depends, FastAPI, Response, status
 
 from .core.auth import init_api_key, require_api_key
@@ -5,6 +7,26 @@ from .core.exception_handlers import include_handlers
 from .schemas import CustomerCreate, CustomerWithId, ProductCreate, ProductWithId
 from .services import create_customer
 from .services_products import create_product
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "handlers": {
+        "file": {
+            "class": "logging.FileHandler",
+            "filename": "auth_audit.log",
+            "formatter": "json",
+        }
+    },
+    "formatters": {
+        "json": {
+            "class": "logging.Formatter",
+            "format": '{"time": "%(asctime)s", "level": "%(levelname)s", "message": "%(message)s", "extra": %(extra)s}',
+        }
+    },
+    "loggers": {"app.core.auth": {"handlers": ["file"], "level": "INFO"}},
+}
+
+logging.config.dictConfig(LOGGING_CONFIG)
 
 app = FastAPI()
 include_handlers(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pydantic==2.11.9
 email-validator==2.3.0
 pydantic_settings==2.11.0
 pytest-timeout==2.3.1
+python-json-logger==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ email-validator==2.3.0
 pydantic_settings==2.11.0
 pytest-timeout==2.3.1
 python-json-logger==3.3.0
+argon2-cffi==25.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ email-validator==2.3.0
 pydantic_settings==2.11.0
 pytest-timeout==2.3.1
 python-json-logger==3.3.0
-argon2-cffi==25.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def _get_logging_config():
 def set_api_key_env(monkeypatch):
     # テスト専用固定キー
     monkeypatch.setenv("API_KEY", "test-secret")
+    monkeypatch.setenv("API_KEY_HASH_SECRET", "hash-secret")
     yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 # tests/conftest.py
+import copy
+import logging.config
+
 import pytest
 from fastapi.testclient import TestClient
+
+from app.main import LOGGING_CONFIG
 
 
 @pytest.fixture(autouse=True)
@@ -39,3 +44,26 @@ def reset_storage():
         with _lock_p:
             _products_by_id.clear()
             _prodid_by_name.clear()
+
+
+@pytest.fixture
+def audit_log_file(tmp_path, monkeypatch, request):
+    """ログファイルを一時ディレクトリに設定、テスト後に元に戻す"""
+    log_file = tmp_path / "auth_audit.log"
+
+    # 元の設定を保存 (deep copy)
+    original_config = copy.deepcopy(LOGGING_CONFIG)
+
+    # 一時的なログファイルパスに変更
+    monkeypatch.setitem(LOGGING_CONFIG["handlers"]["file"], "filename", str(log_file))
+
+    # ロギング設定を適用
+    logging.config.dictConfig(LOGGING_CONFIG)
+
+    # テスト終了後に元の設定を復元
+    def restore_logging():
+        logging.config.dictConfig(original_config)
+
+    request.addfinalizer(restore_logging)
+
+    return log_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,11 @@ import logging.config
 import pytest
 from fastapi.testclient import TestClient
 
-from app.main import LOGGING_CONFIG
+
+def _get_logging_config():
+    from app.main import LOGGING_CONFIG
+
+    return LOGGING_CONFIG
 
 
 @pytest.fixture(autouse=True)
@@ -52,6 +56,7 @@ def audit_log_file(tmp_path, monkeypatch, request):
     log_file = tmp_path / "auth_audit.log"
 
     # 元の設定を保存 (deep copy)
+    LOGGING_CONFIG = _get_logging_config()
     original_config = copy.deepcopy(LOGGING_CONFIG)
 
     # 一時的なログファイルパスに変更

--- a/tests/test_auth_audit_log.py
+++ b/tests/test_auth_audit_log.py
@@ -44,6 +44,7 @@ def test_auth_success_logs_to_audit_file(client, audit_log_file):
     assert "Authentication successful" in last_log["message"]
     assert "client_ip" in last_log
     assert "timestamp" in last_log
+    assert "key_hash" in last_log
 
 
 def test_auth_failure_missing_key_logs_to_audit_file(client, audit_log_file):
@@ -93,3 +94,4 @@ def test_auth_failure_invalid_key_logs_to_audit_file(client, audit_log_file):
     assert "Authentication failed - invalid API key" in last_log["message"]
     assert last_log["reason"] == "invalid_key"
     assert "client_ip" in last_log
+    assert "key_hash" in last_log

--- a/tests/test_auth_audit_log.py
+++ b/tests/test_auth_audit_log.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+from tests.helpers import post_json
+
+
+def _read_new_log_entries(log_file: Path, initial_count: int) -> list[dict]:
+    """新しいログエントリを読み取ってパースする"""
+
+    # ログファイルに新しいエントリが追加されたことを確認
+    assert log_file.exists(), "Audit log file should exist"
+
+    with open(log_file, "r") as f:
+        lines = f.readlines()
+        new_lines = lines[initial_count:]
+
+        # 最後のログエントリを検証
+        assert len(new_lines) > 0, "New log entry should be written"
+        return [json.loads(line) for line in new_lines]
+
+
+def test_auth_success_logs_to_audit_file(client, audit_log_file):
+    """認証成功時に監査ログが記録されることを確認"""
+
+    # ログファイルが存在する場合、既存の行数を記録
+    initial_line_count = 0
+    if audit_log_file.exists():
+        with open(audit_log_file, "r") as f:
+            initial_line_count = len(f.readlines())
+
+    # 有効な API key でリクエスト
+    response = post_json(
+        client,
+        "/customers",
+        {"name": "TestUser", "email": "test@example.com"},
+        api_key="test-secret",
+    )
+    assert response.status_code == 201
+
+    logs = _read_new_log_entries(audit_log_file, initial_line_count)
+    last_log = logs[-1]
+
+    assert last_log["levelname"] == "INFO"
+    assert "Authentication successful" in last_log["message"]
+    assert "client_ip" in last_log
+    assert "timestamp" in last_log
+
+
+def test_auth_failure_missing_key_logs_to_audit_file(client, audit_log_file):
+    """API key が未指定の場合に監査ログが記録されることを確認"""
+
+    initial_line_count = 0
+    if audit_log_file.exists():
+        with open(audit_log_file, "r") as f:
+            initial_line_count = len(f.readlines())
+
+    # API key なしでリクエスト
+    response = client.post(
+        "/customers", json={"name": "TestUser", "email": "test@example.com"}
+    )
+    assert response.status_code == 401
+
+    logs = _read_new_log_entries(audit_log_file, initial_line_count)
+    last_log = logs[-1]
+
+    assert last_log["levelname"] == "WARNING"
+    assert "Authentication failed - missing API key" in last_log["message"]
+    assert last_log["reason"] == "missing_header"
+    assert "client_ip" in last_log
+
+
+def test_auth_failure_invalid_key_logs_to_audit_file(client, audit_log_file):
+    """無効な API key の場合に監査ログが記録されることを確認"""
+
+    initial_line_count = 0
+    if audit_log_file.exists():
+        with open(audit_log_file, "r") as f:
+            initial_line_count = len(f.readlines())
+
+    # 無効な API key でリクエスト
+    response = post_json(
+        client,
+        "/customers",
+        {"name": "TestUser", "email": "test@example.com"},
+        api_key="wrong-key",
+    )
+    assert response.status_code == 401
+
+    logs = _read_new_log_entries(audit_log_file, initial_line_count)
+    last_log = logs[-1]
+
+    assert last_log["levelname"] == "WARNING"
+    assert "Authentication failed - invalid API key" in last_log["message"]
+    assert last_log["reason"] == "invalid_key"
+    assert "client_ip" in last_log

--- a/tests/test_customers_concurrency.py
+++ b/tests/test_customers_concurrency.py
@@ -1,9 +1,12 @@
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
 
+import pytest
+
 from tests.helpers import post_json
 
 
+@pytest.mark.timeout(30)
 def test_many_parallel_posts(client):
     def _post(client, i):
         return post_json(


### PR DESCRIPTION
## 目的（ユーザストーリー 1行）
- X-API-KEY認証がうまくいったかどうかのログを記録する機能を追加したい。
## 変更内容（縦切りの範囲）
- I/F変更: なし
## 動作確認
- `pytest -q`
## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新
Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 認証イベントの監査ログを追加：成功・無効・未提供をタイムスタンプ、クライアントIP、鍵ハッシュ付きで記録。
  - 新しいAPIエンドポイントを追加：ヘルスチェック、顧客作成、商品作成。

- **Chores**
  - ルート直下の *.log を .gitignore に追加。
  - pre-commitでスモークpytestフックを有効化（コミット時実行）。
  - JSONログ出力用依存を追加（python-json-logger）。

- **Tests**
  - 監査ログ出力を検証するテストとログ用フィクスチャを追加。
  - 並列テストに30秒タイムアウトを適用。

- **Documentation**
  - READMEにAPI_KEY_HASH_SECRETの設定手順を追記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->