### PR TITLE
APIキー識別子の追加

### DIFF
--- a/tests/test_auth_audit_log.py
+++ b/tests/test_auth_audit_log.py
@@ -44,6 +44,7 @@ def test_auth_success_logs_to_audit_file(client, audit_log_file):
     assert "Authentication successful" in last_log["message"]
     assert "client_ip" in last_log
     assert "timestamp" in last_log
+    assert "key_hash" in last_log
 
 
 def test_auth_failure_missing_key_logs_to_audit_file(client, audit_log_file):

--- a/tests/test_auth_audit_log.py
+++ b/tests/test_auth_audit_log.py
@@ -93,3 +93,4 @@ def test_auth_failure_invalid_key_logs_to_audit_file(client, audit_log_file):
     assert "Authentication failed - invalid API key" in last_log["message"]
     assert last_log["reason"] == "invalid_key"
     assert "client_ip" in last_log
+    assert "key_hash" in last_log


### PR DESCRIPTION
## 目的（ユーザストーリー 1行）
- APIキーをそのままログに残さずに、どのキーで認証が試行されたかを追跡可能にする
## 変更内容（縦切りの範囲）
- I/F変更: なし
## 動作確認
- `pytest -q`
## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新

Closes #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 監査ログにハッシュ化したキー識別子を含め、成功／失敗／ヘッダー欠落時の追跡性を向上（機能の挙動は不変）
- テスト
  - 監査ログにハッシュ化識別子が出力されることを検証するアサーションを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->