### PR TITLE
slowapiによるレート制限を追加

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,9 @@ GLOBAL_RATE_LIMIT = "100/minute" if TESTING else "10/minute"
 # 認証済みエンドポイント用
 AUTH_RATE_LIMIT = "10000/minute" if TESTING else "5/minute"
 
+# Redis接続情報を環境変数から取得（本番環境用）
+REDIS_URL = os.getenv("REDIS_URL", "")
+
 
 LOGGING_CONFIG = {
     "version": 1,
@@ -73,6 +76,7 @@ limiter = Limiter(
     key_func=get_api_key_for_limit,
     default_limits=[GLOBAL_RATE_LIMIT],  # ← グローバル制限
     headers_enabled=True,  # X-RateLimit-* ヘッダーを有効化
+    storage_uri=REDIS_URL if REDIS_URL else None,  # 本番環境ではRedisを使用
 )
 
 app = FastAPI(title="Order Management API", version="1.0.0", lifespan=lifespan)

--- a/app/main.py
+++ b/app/main.py
@@ -77,14 +77,6 @@ limiter = Limiter(
 
 app = FastAPI(title="Order Management API", version="1.0.0", lifespan=lifespan)
 
-include_handlers(app)
-
-# Limiterをアプリケーションにバインド
-app.state.limiter = limiter
-
-# SlowAPIMiddlewareを追加（これが自動的にレート制限をチェック）
-app.add_middleware(SlowAPIMiddleware)
-
 
 @app.exception_handler(RateLimitExceeded)
 async def rate_limit_handler(request: StarletteRequest, exc: RateLimitExceeded):
@@ -119,6 +111,15 @@ async def rate_limit_handler(request: StarletteRequest, exc: RateLimitExceeded):
         },
         headers=headers,  # レート制限情報をヘッダーにも含める
     )
+
+
+include_handlers(app)
+
+# Limiterをアプリケーションにバインド
+app.state.limiter = limiter
+
+# SlowAPIMiddlewareを追加（これが自動的にレート制限をチェック）
+app.add_middleware(SlowAPIMiddleware)
 
 
 @app.get("/health")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ email-validator==2.3.0
 pydantic_settings==2.11.0
 pytest-timeout==2.3.1
 python-json-logger==3.3.0
+slowapi==0.1.9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,22 @@ def client():
         yield c
 
 
+@pytest.fixture
+def client_with_rate_limit(monkeypatch):
+    """レート制限が有効なテストクライアント"""
+    # レート制限を有効化
+    monkeypatch.setenv("TESTING", "false")
+    monkeypatch.setenv("API_KEY", "test-secret")
+    monkeypatch.setenv("API_KEY_HASH_SECRET", "hash-secret")
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+
 @pytest.fixture(autouse=True)
 def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,12 @@ def client():
 @pytest.fixture(autouse=True)
 def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""
+    from app.core.auth import _blocked_ips, _failed_attempts
     from app.services import _custid_by_email, _customers_by_id, _lock
     from app.services_products import _lock_p, _prodid_by_name, _products_by_id
 
+    _blocked_ips.clear()
+    _failed_attempts.clear()
     with _lock:
         _customers_by_id.clear()
         _custid_by_email.clear()
@@ -44,6 +47,8 @@ def reset_storage():
     try:
         yield
     finally:
+        _blocked_ips.clear()
+        _failed_attempts.clear()
         with _lock:
             _customers_by_id.clear()
             _custid_by_email.clear()
@@ -55,6 +60,10 @@ def reset_storage():
 @pytest.fixture
 def audit_log_file(tmp_path, monkeypatch, request):
     """ログファイルを一時ディレクトリに設定、テスト後に元に戻す"""
+    import os
+
+    print(f"API_KEY in audit_log_file: {os.getenv('API_KEY')}")  # ← デバッグ用
+    print(f"TESTING in audit_log_file: {os.getenv('TESTING')}")  # ← デバッグ用
     log_file = tmp_path / "auth_audit.log"
 
     # 元の設定を保存 (deep copy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ def set_api_key_env(monkeypatch):
     # テスト専用固定キー
     monkeypatch.setenv("API_KEY", "test-secret")
     monkeypatch.setenv("API_KEY_HASH_SECRET", "hash-secret")
+    monkeypatch.setenv("TESTING", "true")
     yield
 
 

--- a/tests/test_global_rate_limit.py
+++ b/tests/test_global_rate_limit.py
@@ -1,0 +1,15 @@
+def test_global_rate_limit_unauthenticated(client, monkeypatch):
+    """認証前のグローバルレート制限を確認"""
+    # レート制限を有効化
+    monkeypatch.setenv("TESTING", "false")
+
+    # 10回までは失敗するが429ではない（401 Unauthorized）
+    for i in range(10):
+        # response = post_json(
+        #     client,
+        #     "/customers",
+        #     {"name": f"User{i}", "email": f"user{i}@example.com"},
+        #     api_key="invalid-key",
+        # )
+        response = client.get("/health")
+        assert response.status_code == 200

--- a/tests/test_ip_blocking.py
+++ b/tests/test_ip_blocking.py
@@ -1,0 +1,56 @@
+from tests.helpers import post_json
+
+
+def test_ip_blocking_after_failed_attempts(client):
+    """5回の認証失敗後、IPがブロックされることを確認"""
+    # 5回失敗する
+    for i in range(5):
+        response = post_json(
+            client,
+            "/customers",
+            {"name": f"User{i}", "email": f"user{i}@example.com"},
+            api_key="invalid-key",
+        )
+        assert response.status_code == 401
+
+    # 6回目は 403 Forbidden (ブロック)
+    response = post_json(
+        client,
+        "/customers",
+        {"name": "User6", "email": "user6@example.com"},
+        api_key="invalid-key",
+    )
+    assert response.status_code == 403
+    assert "Too many failed authentication attempts" in response.json()["detail"]
+
+
+def test_successful_auth_resets_counter(client):
+    """認証成功時に失敗カウンターがリセットされることを確認"""
+    # 3回失敗
+    for i in range(3):
+        response = post_json(
+            client,
+            "/customers",
+            {"name": f"User{i}", "email": f"user{i}@example.com"},
+            api_key="invalid-key",
+        )
+        assert response.status_code == 401
+
+    # 正しいキーで成功
+    response = post_json(
+        client,
+        "/customers",
+        {"name": "ValidUser", "email": "valid@example.com"},
+        api_key="test-secret",
+    )
+    assert response.status_code == 201
+
+    # 再度3回失敗してもカウントリセットによりブロックされない
+    for i in range(3):
+        response = post_json(
+            client,
+            "/customers",
+            {"name": f"User{i+10}", "email": f"user{i+10}@example.com"},
+            api_key="invalid-key",
+        )
+        assert response.status_code == 401


### PR DESCRIPTION
# 概要
ブルートフォース攻撃や過剰アクセスを防ぐため、APIキーごとにリクエスト数を制限する。

# 目的

- セキュリティ（攻撃耐性）と可用性（DoS耐性）を強化

- 公平利用を促進

# 動作確認

- `pytest -q`

# チェックリスト

- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新

Closes #14 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 健康確認・顧客・商品APIにグローバル／認証別のレート制限を導入し、429時に標準化されたJSON応答と関連ヘッダを返却。
  - 接続元IPの失敗カウントに基づく自動ブロック／自動解除と、認証成功時のカウンターリセットを追加。
- テスト
  - テスト用フラグとレート制限対応のテストクライアントを追加し、グローバル/認証制限およびIPブロックの挙動を検証するテストを追加。
- 雑務
  - レート制限ライブラリを依存に追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->