### PR TITLE
/ordersエンドポイントを追加

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -2,8 +2,24 @@ from fastapi import HTTPException, status
 
 
 class Conflict(HTTPException):
-    def __init__(self, code: str, message: str) -> None:
+    def __init__(self, code: str, message: str):
         super().__init__(
             status_code=status.HTTP_409_CONFLICT,
+            detail={"code": code, "message": message},
+        )
+
+
+class BadRequest(HTTPException):
+    def __init__(self, code: str, message: str):
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": code, "message": message},
+        )
+
+
+class NotFound(HTTPException):
+    def __init__(self, code: str, message: str):
+        super().__init__(
+            status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": code, "message": message},
         )

--- a/app/main.py
+++ b/app/main.py
@@ -182,7 +182,7 @@ async def post_order(
     request: Request,  # slowapi のレート制限に必要
     body: OrderCreate,
     response: Response,
-) -> ProductWithId:
+) -> OrderCreateResponse:
     order = create_order(body)
     response.headers["Location"] = f"/orders/{order.order_id}"
     return order

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,3 +1,6 @@
+from datetime import date
+from typing import List
+
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, StrictInt, field_validator
 from pydantic.alias_generators import to_camel
 
@@ -56,5 +59,38 @@ class ProductWithId(BaseModel):
     prod_id: str = Field(min_length=1, max_length=100)
     name: str
     unit_price: int
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class OrderItemCreate(BaseModel):
+    prod_id: str
+    qty: int = Field(ge=1, le=1000)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class OrderCreate(BaseModel):
+    cust_id: str
+    items: List[OrderItemCreate] = Field(min_length=1, max_length=100)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class OrderItemCreateResponse(BaseModel):
+    line_no: int = Field(ge=1)
+    prod_id: str
+    qty: int = Field(ge=1, le=1000)
+    unit_price: int = Field(ge=0, le=1_000_000)
+    line_amount: int = Field(ge=0, le=1_000_000_000)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class OrderCreateResponse(BaseModel):
+    order_id: str
+    order_date: date
+    total_amount: int = Field(ge=0)
+    items: List[OrderItemCreateResponse]
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -64,14 +64,14 @@ class ProductWithId(BaseModel):
 
 
 class OrderItemCreate(BaseModel):
-    prod_id: str
+    prod_id: str = Field(min_length=1, max_length=100)
     qty: int = Field(ge=1, le=1000)
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
 
 class OrderCreate(BaseModel):
-    cust_id: str
+    cust_id: str = Field(min_length=1)
     items: List[OrderItemCreate] = Field(min_length=1, max_length=100)
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
@@ -79,16 +79,16 @@ class OrderCreate(BaseModel):
 
 class OrderItemCreateResponse(BaseModel):
     line_no: int = Field(ge=1)
-    prod_id: str
+    prod_id: str = Field(min_length=1, max_length=100)
     qty: int = Field(ge=1, le=1000)
-    unit_price: int = Field(ge=0, le=1_000_000)
+    unit_price: int = Field(ge=1, le=1_000_000)
     line_amount: int = Field(ge=0, le=1_000_000_000)
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
 
 class OrderCreateResponse(BaseModel):
-    order_id: str
+    order_id: str = Field(min_length=1)
     order_date: date
     total_amount: int = Field(ge=0)
     items: List[OrderItemCreateResponse]

--- a/app/services_orders.py
+++ b/app/services_orders.py
@@ -67,4 +67,5 @@ def create_order(payload: OrderCreate) -> OrderCreateResponse:
         order = OrderCreateResponse(
             order_id=order_id, order_date=date.today(), total_amount=total, items=items
         )
+        _orders_by_id[order_id] = order
         return order

--- a/app/services_orders.py
+++ b/app/services_orders.py
@@ -1,0 +1,70 @@
+import threading
+import uuid
+from datetime import date
+from typing import Dict
+
+from .core.errors import Conflict, NotFound
+from .schemas import OrderCreate, OrderCreateResponse, OrderItemCreateResponse
+from .services_customers import _customers_by_id
+from .services_customers import _lock as _lock_c
+from .services_products import _lock_p, _products_by_id
+
+# In-memory storage
+_lock_o = threading.RLock()
+_orders_by_id: Dict[str, OrderCreateResponse] = {}
+_line_no = 1
+
+
+def new_order_id() -> str:
+    with _lock_o:
+        max_attempts = 100
+        for _ in range(max_attempts):
+            prod_id = f"O_{uuid.uuid4().hex[:8]}"
+            if prod_id not in _orders_by_id:
+                return prod_id
+        raise RuntimeError("Failed to generate unique order ID after maximum attempts")
+
+
+def create_order(payload: OrderCreate) -> OrderCreateResponse:
+    """
+    顧客・商品の存在チェックが必要
+    アイテム(prodId)の重複 NG (同じ商品が複数行に出ない)
+    合計金額はサーバサイドで計算
+    """
+    global _line_no
+
+    with _lock_c:
+        if payload.cust_id not in _customers_by_id:
+            raise NotFound("CUST_NOT_FOUND", f"custId not found: {payload.cust_id}")
+
+    seen = set()
+    total = 0
+    with _lock_p:
+        for it in payload.items:
+            if it.prod_id in seen:
+                raise Conflict("ITEM_DUP", f"duplicate product line: {it.prod_id}")
+            seen.add(it.prod_id)
+            prod = _products_by_id.get(it.prod_id)
+            if not prod:
+                raise NotFound("PROD_NOT_FOUND", f"prodId not found: {it.prod_id}")
+            total += prod.unit_price * it.qty
+
+    with _lock_o:
+        order_id = new_order_id()
+        items = []
+        for it in payload.items:
+            prod = _products_by_id.get(it.prod_id)
+            item = OrderItemCreateResponse(
+                line_no=_line_no,
+                prod_id=it.prod_id,
+                qty=it.qty,
+                unit_price=prod.unit_price,
+                line_amount=prod.unit_price * it.qty,
+            )
+            items.append(item)
+            _line_no += 1
+
+        order = OrderCreateResponse(
+            order_id=order_id, order_date=date.today(), total_amount=total, items=items
+        )
+        return order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""
     from app.core.auth import _blocked_ips, _failed_attempts
     from app.services_customers import _custid_by_email, _customers_by_id, _lock
+    from app.services_orders import _lock_o, _orders_by_id
     from app.services_products import _lock_p, _prodid_by_name, _products_by_id
 
     _blocked_ips.clear()
@@ -71,6 +72,8 @@ def reset_storage():
     with _lock_p:
         _products_by_id.clear()
         _prodid_by_name.clear()
+    with _lock_o:
+        _orders_by_id.clear()
     try:
         yield
     finally:
@@ -82,6 +85,8 @@ def reset_storage():
         with _lock_p:
             _products_by_id.clear()
             _prodid_by_name.clear()
+        with _lock_o:
+            _orders_by_id.clear()
 
 
 @pytest.fixture

--- a/tests/test_orders_api.py
+++ b/tests/test_orders_api.py
@@ -1,0 +1,79 @@
+import re
+from datetime import date
+
+from tests.helpers import post_json
+
+
+def test_create_order_ok(client):
+    # 先に顧客・商品を用意
+    ck = "test-secret"
+    r1 = post_json(client, "/customers", {"name": "A", "email": "a@ex.com"}, api_key=ck)
+    custId = r1.json()["custId"]
+    p1 = post_json(
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key=ck
+    ).json()
+    p2 = post_json(
+        client, "/products", {"name": "Note", "unitPrice": 250}, api_key=ck
+    ).json()
+
+    # 注文
+    today = date.today()
+    od = {
+        "custId": custId,
+        "items": [
+            {"prodId": p1["prodId"], "qty": 2},
+            {"prodId": p2["prodId"], "qty": 1},
+        ],
+    }
+    r = post_json(client, "/orders", od, api_key=ck)
+    assert r.status_code == 201
+    body = r.json()
+    assert re.fullmatch(r"O_[0-9a-f]{8}", body["orderId"])
+    assert body["orderDate"] == today.strftime("%Y-%m-%d")
+    assert body["totalAmount"] == 2 * 100 + 1 * 250
+    assert isinstance(body["items"], list)
+
+
+def test_create_order_missing_customer(client):
+    ck = "test-secret"
+    r = post_json(
+        client,
+        "/orders",
+        {"custId": "C_404", "items": [{"prodId": "P_x", "qty": 1}]},
+        api_key=ck,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"]["code"] == "CUST_NOT_FOUND"
+
+
+def test_create_order_missing_product(client):
+    ck = "test-secret"
+    cust = post_json(
+        client, "/customers", {"name": "A", "email": "a@example.com"}, api_key=ck
+    )
+    r = post_json(
+        client,
+        "/orders",
+        {"custId": cust.json()["custId"], "items": [{"prodId": "P_404", "qty": 1}]},
+        api_key=ck,
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"]["code"] == "PROD_NOT_FOUND"
+
+
+def test_create_order_duplicate_item(client):
+    ck = "test-secret"
+    cust = post_json(
+        client, "/customers", {"name": "A", "email": "a@example.com"}, api_key=ck
+    )
+    prod = post_json(client, "/products", {"name": "Pen", "unitPrice": 100}, api_key=ck)
+    payload = {
+        "custId": cust.json()["custId"],
+        "items": [
+            {"prodId": prod.json()["prodId"], "qty": 1},
+            {"prodId": prod.json()["prodId"], "qty": 2},
+        ],
+    }
+    r = post_json(client, "/orders", payload, api_key=ck)
+    assert r.status_code == 409
+    assert r.json()["detail"]["code"] == "ITEM_DUP"


### PR DESCRIPTION
# スコープ
- POST /orders のみ
- 認可は X-API-KEY 必須
- 合計金額はサーバ計算（クライアントからは送らせない）
- 状態は NEW 固定で作成
- ストレージはインメモリ（Lock あり）

# 非スコープ
- 在庫、支払い、キャンセル、更新、検索、ページング
- DB 永続化

## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 注文作成API（POST /orders）を追加。APIキー保護、エンドポイント単位のレート制限、作成時に Location ヘッダーで新規注文URLを返却。
  - 注文関連のリクエスト/レスポンスモデルとサーバ側の注文処理を追加し、合計金額計算やバリデーションを実施。
- テスト
  - 注文作成フローの包括的なAPIテストを追加（正常系・顧客/商品未存在・重複行対応）。
- その他
  - 400/404のエラーハンドリングを拡充し、一貫したコードとメッセージを返却。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->