### PR TITLE
[WIP]GET /ordersの実装

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -205,7 +205,7 @@ async def get_order(
 ):
     items, total_count = search_orders(cust_id, from_date, to, page, size)
     return {
-        "list": [i.model_dump() for i in items],
+        "list": [i.model_dump(by_alias=True) for i in items],
         "totalCount": total_count,
         "page": page,
         "size": size,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -94,3 +94,11 @@ class OrderCreateResponse(BaseModel):
     items: List[OrderItemCreateResponse]
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class OrderSummary(BaseModel):
+    order_id: str
+    order_date: date
+    total_amount: int = Field(ge=0)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/app/services_orders.py
+++ b/app/services_orders.py
@@ -1,10 +1,16 @@
 import threading
 import uuid
+from collections import defaultdict
 from datetime import date
-from typing import Dict
+from typing import Dict, List, Optional, Tuple
 
 from .core.errors import Conflict, NotFound
-from .schemas import OrderCreate, OrderCreateResponse, OrderItemCreateResponse
+from .schemas import (
+    OrderCreate,
+    OrderCreateResponse,
+    OrderItemCreateResponse,
+    OrderSummary,
+)
 from .services_customers import _customers_by_id
 from .services_customers import _lock as _lock_c
 from .services_products import _lock_p, _products_by_id
@@ -12,6 +18,7 @@ from .services_products import _lock_p, _products_by_id
 # In-memory storage
 _lock_o = threading.RLock()
 _orders_by_id: Dict[str, OrderCreateResponse] = {}
+_orders_by_custid: Dict[str, OrderCreateResponse] = defaultdict(list)
 _line_no = 1
 
 
@@ -25,7 +32,9 @@ def new_order_id() -> str:
         raise RuntimeError("Failed to generate unique order ID after maximum attempts")
 
 
-def create_order(payload: OrderCreate) -> OrderCreateResponse:
+def create_order(
+    payload: OrderCreate, *, today_provider=date.today
+) -> OrderCreateResponse:
     """
     顧客・商品の存在チェックが必要
     アイテム(prodId)の重複 NG (同じ商品が複数行に出ない)
@@ -65,7 +74,55 @@ def create_order(payload: OrderCreate) -> OrderCreateResponse:
             _line_no += 1
 
         order = OrderCreateResponse(
-            order_id=order_id, order_date=date.today(), total_amount=total, items=items
+            order_id=order_id,
+            order_date=today_provider(),
+            total_amount=total,
+            items=items,
         )
         _orders_by_id[order_id] = order
+        _orders_by_custid[payload.cust_id].append(order)
         return order
+
+
+def search_orders(
+    cust_id: Optional[str],
+    from_date: Optional[date],
+    to_date: Optional[date],
+    page: int,
+    size: int,
+) -> Tuple[List[OrderSummary], int]:
+    # ロック内でスナップショットをコピー
+    with _lock_o:
+        orders = (
+            list(_orders_by_custid[cust_id])
+            if cust_id
+            else list(_orders_by_custid.values())
+        )
+
+    # フィルタ
+    if from_date:
+        orders = [o for o in orders if o.order_date >= from_date]
+    if to_date:
+        orders = [o for o in orders if o.order_date <= to_date]
+
+    # 並び順：order_date 降順
+    print(orders)
+    print(type(orders))
+    orders.sort(key=lambda o: o.order_date, reverse=True)
+
+    total_count = len(orders)
+
+    # ページング
+    start = page * size
+    end = start + size
+    page_items = orders[start:end]
+
+    summaries = [
+        OrderSummary(
+            order_id=o.order_id,
+            order_date=o.order_date,
+            total_amount=o.total_amount,
+        )
+        for o in page_items
+    ]
+    return summaries, total_count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""
     from app.core.auth import _blocked_ips, _failed_attempts
     from app.services_customers import _custid_by_email, _customers_by_id, _lock
-    from app.services_orders import _lock_o, _orders_by_id
+    from app.services_orders import _lock_o, _orders_by_custid, _orders_by_id
     from app.services_products import _lock_p, _prodid_by_name, _products_by_id
 
     _blocked_ips.clear()
@@ -95,6 +95,7 @@ def reset_storage():
         _prodid_by_name.clear()
     with _lock_o:
         _orders_by_id.clear()
+        _orders_by_custid.clear()
     try:
         yield
     finally:
@@ -108,6 +109,7 @@ def reset_storage():
             _prodid_by_name.clear()
         with _lock_o:
             _orders_by_id.clear()
+            _orders_by_custid.clear()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,36 @@
 # tests/conftest.py
 import copy
 import logging.config
+from datetime import date as _date
 
 import pytest
 from fastapi.testclient import TestClient
+
+FIXED_TODAY = (2025, 10, 6)
 
 
 def _get_logging_config():
     from app.main import LOGGING_CONFIG
 
     return LOGGING_CONFIG
+
+
+@pytest.fixture
+def frozen_today(monkeypatch):
+    """
+    app.services_orders モジュール内の date.today() を固定する。
+    """
+
+    class _FixedDate(_date):
+        @classmethod
+        def today(cls):
+            y, m, d = FIXED_TODAY
+            return cls(y, m, d)
+
+    import app.services_orders as mod
+
+    monkeypatch.setattr(mod, "date", _FixedDate, raising=True)
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_orders_api.py
+++ b/tests/test_orders_api.py
@@ -77,3 +77,39 @@ def test_create_order_duplicate_item(client):
     r = post_json(client, "/orders", payload, api_key=ck)
     assert r.status_code == 409
     assert r.json()["detail"]["code"] == "ITEM_DUP"
+
+
+# def test_get_order(client):
+#     ck = "test-secret"
+#     r = client.get(
+#         "/orders",
+#         params={
+#             "custId": "C_1234",
+#             "from": date.today(),
+#             "to": date.today(),
+#             "page": 0,
+#             "size": 20
+#         },
+#         headers={"X-API-KEY": ck}
+#     )
+#     print(r.json())
+
+
+def test_create_order_sets_fixed_date(client, frozen_today):
+    ck = "test-secret"
+    cust = post_json(
+        client, "/customers", {"name": "A", "email": "a@ex.com"}, api_key=ck
+    ).json()
+    prod = post_json(
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key=ck
+    ).json()
+
+    r = post_json(
+        client,
+        "/orders",
+        {"custId": cust["custId"], "items": [{"prodId": prod["prodId"], "qty": 2}]},
+        api_key=ck,
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["orderDate"] == "2025-10-06"

--- a/tests/test_orders_get_api.py
+++ b/tests/test_orders_get_api.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import List
 
 from app.schemas import OrderCreate, OrderItemCreate
 from app.services_orders import create_order
@@ -61,10 +62,101 @@ def test_get_orders_filter_by_custid(client):
     r = client.get(
         "/orders", params={"custId": cust_ids[0]}, headers={"X-API-KEY": api_key}
     )
-    print(r.json())
     assert r.status_code == 200
     body = r.json()
     assert body["totalCount"] == 3
     assert len(body["list"]) == 3
     item = body["list"][0]
     assert {"orderId", "orderDate", "totalAmount"} <= set(item.keys())
+
+
+def test_get_orders_filter_from(client):
+    api_key = "test-secret"
+    _prepare_basic_data(client)
+
+    r = client.get(
+        "/orders",
+        params={"from": date.fromisoformat("2025-10-02")},
+        headers={"X-API-KEY": api_key},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["totalCount"] == 3
+    dates: List[str] = [it["orderDate"] for it in body["list"]]
+    assert set(dates) == {"2025-10-02", "2025-10-03", "2025-10-04"}
+
+
+def test_get_orders_filter_to(client):
+    api_key = "test-secret"
+    _prepare_basic_data(client)
+
+    r = client.get(
+        "/orders",
+        params={"to": date.fromisoformat("2025-10-02")},
+        headers={"X-API-KEY": api_key},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["totalCount"] == 2
+    dates: List[str] = [it["orderDate"] for it in body["list"]]
+    assert set(dates) == {"2025-10-01", "2025-10-02"}
+
+
+def test_get_orders_filter_from_to(client):
+    api_key = "test-secret"
+    _prepare_basic_data(client)
+
+    r = client.get(
+        "/orders",
+        params={
+            "from": date.fromisoformat("2025-10-02"),
+            "to": date.fromisoformat("2025-10-02"),
+        },
+        headers={"X-API-KEY": api_key},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["totalCount"] == 1
+    assert len(body["list"]) == 1
+    assert body["list"][0]["orderDate"] == "2025-10-02"
+
+
+def test_get_orders_pagination(client):
+    api_key = "test-secret"
+    _prepare_basic_data(client)
+
+    r0 = client.get(
+        "/orders", params={"page": 0, "size": 1}, headers={"X-API-KEY": api_key}
+    ).json()
+    r1 = client.get(
+        "/orders", params={"page": 1, "size": 1}, headers={"X-API-KEY": api_key}
+    ).json()
+    r2 = client.get(
+        "/orders", params={"page": 2, "size": 1}, headers={"X-API-KEY": api_key}
+    ).json()
+    r3 = client.get(
+        "/orders", params={"page": 3, "size": 1}, headers={"X-API-KEY": api_key}
+    ).json()
+
+    assert (
+        r0["totalCount"]
+        == r1["totalCount"]
+        == r2["totalCount"]
+        == r3["totalCount"]
+        == 4
+    )
+    assert len(r0["list"]) == len(r1["list"]) == len(r2["list"]) == len(r3["list"]) == 1
+    assert r0["list"][0]["orderDate"] == "2025-10-04"
+    assert r1["list"][0]["orderDate"] == "2025-10-03"
+    assert r2["list"][0]["orderDate"] == "2025-10-02"
+    assert r3["list"][0]["orderDate"] == "2025-10-01"
+
+
+def test_get_orders_sorted_desc_by_default(client):
+    api_key = "test-secret"
+    _prepare_basic_data(client)
+
+    r = client.get("/orders", headers={"X-API-KEY": api_key})
+    assert r.status_code == 200
+    dates: List[str] = [it["orderDate"] for it in r.json()["list"]]
+    assert dates == sorted(dates, reverse=True)

--- a/tests/test_orders_get_api.py
+++ b/tests/test_orders_get_api.py
@@ -1,0 +1,70 @@
+from datetime import date
+
+from app.schemas import OrderCreate, OrderItemCreate
+from app.services_orders import create_order
+from tests.helpers import post_json
+
+
+def _mk_order_for_date(cust_id: str, prod_id: str, qty: int, ymd: str):
+    payload = OrderCreate(
+        cust_id=cust_id,
+        items=[OrderItemCreate(prod_id=prod_id, qty=qty)],
+    )
+
+    def fixed():
+        return date.fromisoformat(ymd)
+
+    return create_order(payload, today_provider=fixed)
+
+
+def _prepare_basic_data(client):
+    """顧客2人、商品2つ、日付違いの注文を複数用意"""
+    api_key = "test-secret"
+
+    c1 = post_json(
+        client,
+        "/customers",
+        {"name": "Alice", "email": "a@example.com"},
+        api_key=api_key,
+    ).json()
+    cust_id = c1["custId"]
+    c2 = post_json(
+        client, "/customers", {"name": "Bob", "email": "b@example.com"}, api_key=api_key
+    ).json()
+    cust_id2 = c2["custId"]
+
+    p1 = post_json(
+        client, "/products", {"name": "Pen", "unitPrice": 100}, api_key=api_key
+    ).json()
+    p2 = post_json(
+        client, "/products", {"name": "Note", "unitPrice": 250}, api_key=api_key
+    ).json()
+
+    # 受注（固定日付で3件：10/01, 10/02, 10/03）
+    _mk_order_for_date(cust_id, p1["prodId"], 1, "2025-10-01")  # total=100
+    _mk_order_for_date(cust_id, p2["prodId"], 2, "2025-10-02")  # total=500
+    _mk_order_for_date(cust_id, p1["prodId"], 3, "2025-10-03")  # total=300
+    _mk_order_for_date(cust_id2, p2["prodId"], 4, "2025-10-04")  # total=1000
+
+    return (cust_id, cust_id2), (p1["prodId"], p2["prodId"])
+
+
+def test_get_orders_requires_api_key(client):
+    r = client.get("/orders")
+    assert r.status_code == 401
+
+
+def test_get_orders_filter_by_custid(client):
+    api_key = "test-secret"
+    cust_ids, _ = _prepare_basic_data(client)
+
+    r = client.get(
+        "/orders", params={"custId": cust_ids[0]}, headers={"X-API-KEY": api_key}
+    )
+    print(r.json())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["totalCount"] == 3
+    assert len(body["list"]) == 3
+    item = body["list"][0]
+    assert {"orderId", "orderDate", "totalAmount"} <= set(item.keys())


### PR DESCRIPTION
テスト実装中なのですが、coderabbitaiに聞きたいことがありDraft PR作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 注文一覧API「GET /orders」を追加（APIキー必須・エンドポイント単位のレート制限）。
  - クエリ: custId, from, to, page, size に対応。日付降順で返却し、フィルタリング・ページネーションをサポート。
  - レスポンスに items、totalCount、page、size を含み、各アイテムは orderId・orderDate・totalAmount を提供。

- テスト
  - /orders の認可、フィルタ、ソート、ページネーションの網羅テストを追加。
  - 注文作成時の orderDate を固定して検証し、結果の再現性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->