### PR TITLE
GET /ordersのクエリからcustIdを削除

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -35,7 +35,7 @@ FAILED_ATTEMPTS_WINDOW_MINUTES = 5  # 5分以内の失敗をカウントする
 # APIキーと顧客IDのマッピング(動的に更新される)
 _lock_auth = threading.RLock()
 _api_key_to_customer: Dict[str, Optional[str]] = {}
-_admin_api_keys = {"admin_api_key", "test-secret"}  # 管理者キーのセット
+_admin_api_keys = {"admin-api-key", "test-secret"}  # 管理者キーのセット
 
 
 def initialize_api_keys():
@@ -47,12 +47,11 @@ def initialize_api_keys():
     with _lock_auth:
         _api_key_to_customer.clear()
         # 管理者キー(常にNone)
-        _api_key_to_customer["admin_api_key"] = None
-        _api_key_to_customer["test-secret"] = None
+        for admin_key in _admin_api_keys:
+            _api_key_to_customer.setdefault(admin_key, None)
         # 一般ユーザーキー(未バインド状態)
-        _api_key_to_customer["test-api-key-1"] = None
-        _api_key_to_customer["test-api-key-2"] = None
-        _api_key_to_customer["test-api-key"] = None
+        for api_key in _VALID_API_KEYS:
+            _api_key_to_customer[api_key] = None
 
 
 def is_valid_api_key(api_key: str) -> bool:

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from .core.auth import (
     bind_api_key_to_customer,
     get_customer_id_from_api_key,
     init_api_key,
+    initialize_api_keys,
     is_admin_api_key,
     is_api_key_bound,
     is_valid_api_key,
@@ -71,6 +72,7 @@ async def lifespan(app: FastAPI):
     # スタートアップ処理
     logging.config.dictConfig(LOGGING_CONFIG)
     init_api_key()
+    initialize_api_keys()
     yield
     # シャットダウン処理（必要に応じて追加）
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, StrictInt, field_validator
 from pydantic.alias_generators import to_camel
@@ -102,3 +102,11 @@ class OrderSummary(BaseModel):
     total_amount: int = Field(ge=0)
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class AuthContext(BaseModel):
+    """認証済みユーザのコンテキスト情報"""
+
+    api_key: str
+    customer_id: Optional[str]  # Noneの場合は管理者
+    is_admin: bool

--- a/app/services_orders.py
+++ b/app/services_orders.py
@@ -32,14 +32,15 @@ def new_order_id() -> str:
         raise RuntimeError("Failed to generate unique order ID after maximum attempts")
 
 
-def create_order(
-    payload: OrderCreate, *, today_provider=date.today
-) -> OrderCreateResponse:
+def create_order(payload: OrderCreate, *, today_provider=None) -> OrderCreateResponse:
     """
     顧客・商品の存在チェックが必要
     アイテム(prodId)の重複 NG (同じ商品が複数行に出ない)
     合計金額はサーバサイドで計算
     """
+    if today_provider is None:
+        today_provider = date.today
+
     global _line_no
 
     with _lock_c:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,10 @@ def frozen_today(monkeypatch):
 def set_api_key_env(monkeypatch):
     # テスト専用固定キー
     monkeypatch.setenv("API_KEY", "test-secret")
-    monkeypatch.setenv("API_KEYS", "test-secret,new-test-key")
+    monkeypatch.setenv(
+        "API_KEYS",
+        "test-secret,new-test-key,test-api-key-1,test-api-key-2,admin-api-key",
+    )
     monkeypatch.setenv("API_KEY_HASH_SECRET", "hash-secret")
     monkeypatch.setenv("TESTING", "true")
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,13 +80,14 @@ def client_with_rate_limit(monkeypatch):
 @pytest.fixture(autouse=True)
 def reset_storage():
     """各テストの前後でインメモリストレージを確実にクリア"""
-    from app.core.auth import _blocked_ips, _failed_attempts
+    from app.core.auth import _blocked_ips, _failed_attempts, initialize_api_keys
     from app.services_customers import _custid_by_email, _customers_by_id, _lock
     from app.services_orders import _lock_o, _orders_by_custid, _orders_by_id
     from app.services_products import _lock_p, _prodid_by_name, _products_by_id
 
     _blocked_ips.clear()
     _failed_attempts.clear()
+    initialize_api_keys()
     with _lock:
         _customers_by_id.clear()
         _custid_by_email.clear()
@@ -101,6 +102,7 @@ def reset_storage():
     finally:
         _blocked_ips.clear()
         _failed_attempts.clear()
+        initialize_api_keys()
         with _lock:
             _customers_by_id.clear()
             _custid_by_email.clear()


### PR DESCRIPTION
## 目的（ユーザストーリー 1行）
- ユースケースとして、顧客が自分以外の人の注文を確認できるのはまずい気がしたので機能を変更したい。
## 変更内容（縦切りの範囲）
- Controller / Service  / テスト
- I/F変更: なし
## 動作確認
- `pytest -q`
## チェックリスト
- [ ] 小さなPR（~400行 / 10ファイル以内）
- [ ] 命名・ログ・メッセージ統一
- [ ] README / API ドキュメント更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ランタイムでのAPIキー管理と認証コンテキストを追加し、管理者/一般ユーザーの権限を区別
  - 一般ユーザーのAPIキーを顧客に紐付け可能に
- 仕様変更
  - 認証情報に基づき注文取得範囲を制限（一般は自分の注文のみ、管理者は全件）
  - 認証/権限エラーに対する適切な401/403レスポンスを追加
- テスト
  - 自分の注文のみ取得できることを検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->